### PR TITLE
feat: check for hurl installation on startup

### DIFF
--- a/server/cli.ts
+++ b/server/cli.ts
@@ -3,6 +3,23 @@ import { createApp } from "./index.js";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import { mkdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+// Check if hurl is installed
+function checkHurlInstalled(): void {
+  try {
+    execSync("hurl --version", { stdio: "ignore" });
+  } catch {
+    console.error("\x1b[31mError: hurl is not installed or not in PATH.\x1b[0m");
+    console.error("");
+    console.error("Hurler requires hurl to run HTTP requests.");
+    console.error("Install it from: https://hurl.dev/docs/installation.html");
+    console.error("");
+    process.exit(1);
+  }
+}
+
+checkHurlInstalled();
 
 const { values } = parseArgs({
   options: {


### PR DESCRIPTION
Fixes #5

## Changes
- Added check at CLI startup to verify hurl is installed
- Shows helpful error message with installation link if missing
- Exits with code 1 if hurl is not found

## Error Output
When hurl is not installed:
```
Error: hurl is not installed or not in PATH.

Hurler requires hurl to run HTTP requests.
Install it from: https://hurl.dev/docs/installation.html
```