### PR TITLE
feat: add system theme support (light/dark mode)

### DIFF
--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -15,6 +15,49 @@ import {
   bracketMatching,
 } from "@codemirror/language";
 import { javascript } from "@codemirror/lang-javascript";
+import { useTheme } from "@/lib/theme-context";
+
+// Light theme for CodeMirror
+const lightTheme = EditorView.theme({
+  "&": {
+    backgroundColor: "#ffffff",
+    color: "#1f2937",
+  },
+  ".cm-content": {
+    caretColor: "#1f2937",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "#1f2937",
+  },
+  "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+    backgroundColor: "#d1d5db",
+  },
+  ".cm-panels": {
+    backgroundColor: "#f3f4f6",
+    color: "#1f2937",
+  },
+  ".cm-panels.cm-panels-top": {
+    borderBottom: "1px solid #e5e7eb",
+  },
+  ".cm-panels.cm-panels-bottom": {
+    borderTop: "1px solid #e5e7eb",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "#f9fafb",
+  },
+  ".cm-gutters": {
+    backgroundColor: "#f9fafb",
+    color: "#9ca3af",
+    border: "none",
+    borderRight: "1px solid #e5e7eb",
+  },
+  ".cm-activeLineGutter": {
+    backgroundColor: "#f3f4f6",
+  },
+  ".cm-lineNumbers .cm-gutterElement": {
+    color: "#9ca3af",
+  },
+}, { dark: false });
 
 interface CodeEditorProps {
   value: string;
@@ -35,13 +78,20 @@ export function CodeEditor({
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   const valueRef = useRef(value);
+  const theme = useTheme();
 
   onChangeRef.current = onChange;
   valueRef.current = value;
 
-  // Create editor on mount
+  // Create editor on mount or when theme changes
   useEffect(() => {
     if (!editorRef.current) return;
+
+    // Destroy existing editor
+    if (viewRef.current) {
+      viewRef.current.destroy();
+      viewRef.current = null;
+    }
 
     const extensions = [
       lineNumbers(),
@@ -50,7 +100,8 @@ export function CodeEditor({
       highlightActiveLine(),
       bracketMatching(),
       syntaxHighlighting(defaultHighlightStyle),
-      oneDark,
+      // Apply theme based on system preference
+      theme === "dark" ? oneDark : lightTheme,
       keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
@@ -88,7 +139,7 @@ export function CodeEditor({
       viewRef.current?.destroy();
       viewRef.current = null;
     };
-  }, [language, minHeight]);
+  }, [language, minHeight, theme]);
 
   // Sync value changes from parent
   useEffect(() => {

--- a/src/components/request-editor.tsx
+++ b/src/components/request-editor.tsx
@@ -9,6 +9,49 @@ import { EditorView, keymap, lineNumbers, drawSelection, highlightActiveLine } f
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { syntaxHighlighting, defaultHighlightStyle, bracketMatching } from "@codemirror/language";
+import { useTheme } from "@/lib/theme-context";
+
+// Light theme for CodeMirror
+const lightTheme = EditorView.theme({
+  "&": {
+    backgroundColor: "#ffffff",
+    color: "#1f2937",
+  },
+  ".cm-content": {
+    caretColor: "#1f2937",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "#1f2937",
+  },
+  "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+    backgroundColor: "#d1d5db",
+  },
+  ".cm-panels": {
+    backgroundColor: "#f3f4f6",
+    color: "#1f2937",
+  },
+  ".cm-panels.cm-panels-top": {
+    borderBottom: "1px solid #e5e7eb",
+  },
+  ".cm-panels.cm-panels-bottom": {
+    borderTop: "1px solid #e5e7eb",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "#f9fafb",
+  },
+  ".cm-gutters": {
+    backgroundColor: "#f9fafb",
+    color: "#9ca3af",
+    border: "none",
+    borderRight: "1px solid #e5e7eb",
+  },
+  ".cm-activeLineGutter": {
+    backgroundColor: "#f3f4f6",
+  },
+  ".cm-lineNumbers .cm-gutterElement": {
+    color: "#9ca3af",
+  },
+}, { dark: false });
 
 interface RequestEditorProps {
   fileName: string | null;
@@ -38,13 +81,14 @@ export function RequestEditor({
   const onRunRef = useRef(onRun);
   const onSaveRef = useRef(onSave);
   const contentRef = useRef(content);
+  const theme = useTheme();
 
   onChangeRef.current = onChange;
   onRunRef.current = onRun;
   onSaveRef.current = onSave;
   contentRef.current = content;
 
-  // Create/destroy editor when fileName changes (null <-> value)
+  // Create/destroy editor when fileName or theme changes
   useEffect(() => {
     if (!fileName || !editorRef.current) {
       if (viewRef.current) {
@@ -68,7 +112,8 @@ export function RequestEditor({
         highlightActiveLine(),
         bracketMatching(),
         syntaxHighlighting(defaultHighlightStyle),
-        oneDark,
+        // Apply theme based on system preference
+        theme === "dark" ? oneDark : lightTheme,
         keymap.of([
           ...defaultKeymap,
           ...historyKeymap,
@@ -104,7 +149,7 @@ export function RequestEditor({
       viewRef.current?.destroy();
       viewRef.current = null;
     };
-  }, [fileName]);
+  }, [fileName, theme]);
 
   // Sync content into existing editor when it changes externally
   useEffect(() => {

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type Theme = "light" | "dark";
+
+const ThemeContext = createContext<Theme>("light");
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== "undefined") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    }
+    return "light";
+  });
+
+  useEffect(() => {
+    // Apply theme class to document
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    // Listen for system preference changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    
+    const handleChange = (e: MediaQueryListEvent) => {
+      setTheme(e.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './lib/theme-context'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## 🔗 Preview
**https://hurler-preview.sidia.li**

Test by toggling your system appearance between light and dark mode!

## Changes

### 1. Light theme for code editors
- Code editors now use a proper light theme when in light mode
- White background with appropriate syntax highlighting colors
- Matches the rest of the app's light appearance

### 2. System theme detection
- App automatically detects system color scheme preference
- Switches between light and dark mode accordingly
- Listens for system preference changes in real-time

### Technical Details
- Created `ThemeProvider` context that wraps the app
- Applies `.dark` class to document root based on `prefers-color-scheme`
- Both `CodeEditor` (body editor) and `RequestEditor` (raw editor) respect the theme
- Custom light theme for CodeMirror that matches the app's design system