### PR TITLE
fix: prevent code editors from overflowing container

### DIFF
--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -109,7 +109,7 @@ export function CodeEditor({
         }
       }),
       EditorView.theme({
-        "&": { minHeight, fontSize: "13px" },
+        "&": { minHeight, fontSize: "13px", maxWidth: "100%" },
         ".cm-scroller": { overflow: "auto" },
         ".cm-content": {
           fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
@@ -118,6 +118,7 @@ export function CodeEditor({
           fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
         },
       }),
+      EditorView.lineWrapping,
     ];
 
     // Add language support (use JavaScript for JSON syntax highlighting)
@@ -156,7 +157,7 @@ export function CodeEditor({
   return (
     <div
       ref={editorRef}
-      className={`border-input overflow-hidden rounded-md border shadow-xs ${className}`}
+      className={`border-input overflow-hidden rounded-md border shadow-xs w-full max-w-full ${className}`}
     />
   );
 }

--- a/src/components/request-editor.tsx
+++ b/src/components/request-editor.tsx
@@ -132,11 +132,12 @@ export function RequestEditor({
           }
         }),
         EditorView.theme({
-          "&": { height: "100%", fontSize: "13px" },
+          "&": { height: "100%", fontSize: "13px", maxWidth: "100%" },
           ".cm-scroller": { overflow: "auto" },
           ".cm-content": { fontFamily: "'JetBrains Mono', 'Fira Code', monospace" },
           ".cm-gutters": { fontFamily: "'JetBrains Mono', 'Fira Code', monospace" },
         }),
+        EditorView.lineWrapping,
       ],
     });
 


### PR DESCRIPTION
Fixes #10

## 🔗 Preview
**https://hurler-preview.sidia.li**

## Problem
Both the raw view code editor and body editor in the visual view were overflowing past the page container width.

## Solution
- Added `EditorView.lineWrapping` extension to wrap long lines instead of horizontal scrolling
- Added `maxWidth: 100%` constraint to editor containers
- Added `w-full max-w-full` classes to body editor container

Now editors properly respect their container bounds and wrap content as needed.