### PR TITLE
fix: hide empty Ungrouped section when all files are categorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- "Ungrouped" sidebar section now hidden when all files are assigned to sections (#12)
+
 ## [0.3.1] - 2026-02-10
 
 ### Fixed

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -369,8 +369,8 @@ export function Sidebar({
             );
           })}
 
-          {/* Ungrouped section */}
-          {(ungroupedFiles.length > 0 || metadata.sections.length > 0) && (
+          {/* Ungrouped section - only show if there are ungrouped files */}
+          {ungroupedFiles.length > 0 && (
             <div>
               {metadata.sections.length > 0 &&
                 renderSectionHeader("__ungrouped__", "Ungrouped", true)}


### PR DESCRIPTION
Fixes #12

## Problem
The "Ungrouped" sidebar section was visible even when all hurl files were assigned to custom sections.

## Solution
Changed the conditional rendering to only show the "Ungrouped" section when there are actually ungrouped files.

**Before:** Section header shown if `metadata.sections.length > 0`
**After:** Section only shown if `ungroupedFiles.length > 0`

## Preview
https://hurler-preview.sidia.li