### PR TITLE
feat: add Captures tab to response pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- "Captures" tab in response pane showing captured values when request has captures (#14)
+
 ## [0.3.2] - 2026-02-10
 
 ### Fixed


### PR DESCRIPTION
Closes #14

## Changes
When a request has `[Captures]` defined and values are captured during execution, a new **Captures** tab appears in the response pane showing each capture's name and value.

## Screenshot
The tab shows:
- Blue badge with count of captures
- Each capture displayed as `name = value`
- Styled consistently with existing tabs (Asserts, Headers, etc.)

## Preview
https://hurler-preview.sidia.li