### PR TITLE
feat: add ability to rename hurl files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Ability to rename hurl files via sidebar menu with rename modal (#16)
+
 ## [0.4.0] - 2026-02-10
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,19 @@ export default function App() {
     [activeFile, loadFiles, metadata]
   );
 
+  const handleRenameFile = useCallback(
+    async (oldName: string, newName: string) => {
+      const result = await api.renameFile(oldName, newName);
+      // If the renamed file was active, update activeFile to new name
+      if (activeFile === oldName) {
+        setActiveFile(result.newName);
+      }
+      await loadFiles();
+      await loadMetadata();
+    },
+    [activeFile, loadFiles, loadMetadata]
+  );
+
   const handleSave = useCallback(async () => {
     if (!activeFile) return;
     await api.updateFile(activeFile, editorContent);
@@ -150,6 +163,7 @@ export default function App() {
             onSelectFile={handleSelectFile}
             onCreateFile={handleCreateFile}
             onDeleteFile={handleDeleteFile}
+            onRenameFile={handleRenameFile}
             metadata={metadata}
             onUpdateMetadata={handleUpdateMetadata}
             environments={environments}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -46,6 +46,7 @@ interface SidebarProps {
   onSelectFile: (name: string) => void;
   onCreateFile: (name: string) => void;
   onDeleteFile: (name: string) => void;
+  onRenameFile: (oldName: string, newName: string) => void;
   metadata: Metadata;
   onUpdateMetadata: (metadata: Metadata) => void;
   environments: string[];
@@ -64,6 +65,7 @@ export function Sidebar({
   onSelectFile,
   onCreateFile,
   onDeleteFile,
+  onRenameFile,
   metadata,
   onUpdateMetadata,
   environments,
@@ -73,6 +75,9 @@ export function Sidebar({
 }: SidebarProps) {
   const [showNewDialog, setShowNewDialog] = useState(false);
   const [newFileName, setNewFileName] = useState("");
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [renamingFile, setRenamingFile] = useState<string | null>(null);
+  const [renameNewName, setRenameNewName] = useState("");
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
   const [editingSectionId, setEditingSectionId] = useState<string | null>(null);
   const [editingSectionName, setEditingSectionName] = useState("");
@@ -205,6 +210,17 @@ export function Sidebar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              setRenamingFile(file);
+              setRenameNewName(file);
+              setShowRenameDialog(true);
+            }}
+          >
+            <Pencil className="mr-2 h-4 w-4" />
+            Rename
+          </DropdownMenuItem>
           {metadata.sections.length > 0 && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>
@@ -451,6 +467,44 @@ export function Sidebar({
             </Button>
             <Button onClick={handleCreate} disabled={!newFileName.trim()}>
               Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showRenameDialog} onOpenChange={setShowRenameDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Request</DialogTitle>
+          </DialogHeader>
+          <Input
+            placeholder="New name"
+            value={renameNewName}
+            onChange={(e) => setRenameNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && renameNewName.trim() && renamingFile) {
+                onRenameFile(renamingFile, renameNewName.trim());
+                setShowRenameDialog(false);
+                setRenamingFile(null);
+              }
+            }}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowRenameDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (renamingFile && renameNewName.trim()) {
+                  onRenameFile(renamingFile, renameNewName.trim());
+                  setShowRenameDialog(false);
+                  setRenamingFile(null);
+                }
+              }}
+              disabled={!renameNewName.trim()}
+            >
+              Rename
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,12 @@ export const updateFile = (name: string, content: string) =>
 export const deleteFile = (name: string) =>
   fetchJSON<{ ok: boolean }>(`${BASE}/files/${name}`, { method: "DELETE" });
 
+export const renameFile = (name: string, newName: string) =>
+  fetchJSON<{ oldName: string; newName: string }>(`${BASE}/files/${name}`, {
+    method: "PATCH",
+    body: JSON.stringify({ newName }),
+  });
+
 // Environments
 export const listEnvironments = () =>
   fetchJSON<string[]>(`${BASE}/environments`);


### PR DESCRIPTION
Closes #16

## Changes
- Added "Rename" option to file dropdown menu in sidebar
- Added rename modal dialog for entering new name
- Added `PATCH /api/files/:name` endpoint for server-side rename
- Section assignments (metadata) are preserved when renaming
- If the renamed file is currently active, the editor updates to the new name

## Preview
https://hurler-preview.sidia.li