### PR TITLE
fix: exclude .secrets.env from environment list

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,8 @@ export function createApp(dataDir: string) {
   app.get("/api/environments", async (_req: Request, res: Response) => {
     await ensureDirs();
     const files = await fs.readdir(ENVIRONMENTS_DIR);
-    const envFiles = files.filter((f) => f.endsWith(".env"));
+    // Filter for .env files but exclude .secrets.env files (they're paired with main env)
+    const envFiles = files.filter((f) => f.endsWith(".env") && !f.endsWith(".secrets.env"));
     res.json(envFiles.map((f) => f.replace(/\.env$/, "")));
   });
 


### PR DESCRIPTION
## Summary

Fixes #20

## Problem

When listing environments, both `.env` and `.secrets.env` files were being shown as separate options. For example, an environment called "e2e" would show as both "e2e" and "e2e.secrets" in the selector.

## Solution

Updated the environment listing endpoint to filter out `.secrets.env` files. These are paired with their main `.env` file and should not be listed separately.

## Changes

- `server/index.ts`: Added filter to exclude files ending with `.secrets.env`