### PR TITLE
fix: widen manage environments modal

### DIFF
--- a/src/components/env-editor.tsx
+++ b/src/components/env-editor.tsx
@@ -163,7 +163,7 @@ export function EnvEditor({
   return (
     <>
       <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-        <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Manage Environments</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary

Makes the Manage Environments modal wider so key/value inputs have more room.

## Changes

- Changed `max-w-2xl` (672px) → `max-w-4xl` (896px) on DialogContent

Fixes #26