### PR TITLE
fix: make env editor modal body scrollable

### DIFF
--- a/src/components/env-editor.tsx
+++ b/src/components/env-editor.tsx
@@ -202,7 +202,7 @@ export function EnvEditor({
           </div>
 
           {selectedEnv && (
-            <ScrollArea className="flex-1 max-h-[400px]">
+            <ScrollArea className="flex-1 min-h-0 overflow-auto">
               <div className="space-y-4 pr-4">
                 {/* Variables Section */}
                 <div className="space-y-2">


### PR DESCRIPTION
## Summary
Fixes the manage environments modal body not scrolling when there are many environment variables or secrets.

## Problem
The `ScrollArea` had a hardcoded `max-h-[400px]` that did not work well with flex layout. When content exceeded that height, it overflowed and covered the save button.

## Solution
Replaced `max-h-[400px]` with `min-h-0 overflow-auto` which allows the ScrollArea to:
- Fill available space via `flex-1`
- Shrink properly in flex context via `min-h-0`
- Scroll when content exceeds available space

Fixes #32