### PR TITLE
fix: sidebar scrolls when content overflows

### DIFF
--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -93,7 +93,7 @@ export function AppLayout({ sidebar, editor, response }: AppLayoutProps) {
         <span className="text-sm font-semibold tracking-tight">Hurler</span>
       </div>
       <div className="flex flex-1 min-h-0 overflow-hidden">
-      <div style={{ width: sidebarWidth }} className="shrink-0 overflow-hidden">
+      <div style={{ width: sidebarWidth }} className="shrink-0 h-full overflow-hidden">
         {sidebar}
       </div>
       <DragHandle direction="horizontal" onDrag={onSidebarDrag} />

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -494,7 +494,7 @@ export function Sidebar({
         </div>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="p-1">
           <DndContext
             sensors={sensors}


### PR DESCRIPTION
Fixes #38

## Problem
Request sidebar gets cut off when there are lots of requests or the window is small.

## Solution
- Added `h-full` to sidebar container in AppLayout so it has proper height constraints
- Added `min-h-0` to ScrollArea in Sidebar for proper flex behavior

The ScrollArea was already there, it just needed the parent to have explicit height and the flex item needed `min-h-0` to shrink properly.

## Preview
https://hurler-preview.sidia.li