### PR TITLE
feat: show project directory name in header and tab title

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -18,13 +18,16 @@ interface Metadata {
 
 const DEFAULT_METADATA: Metadata = { sections: [], fileGroups: {} };
 
-export function createApp(dataDir: string) {
+export function createApp(dataDir: string, projectName?: string) {
   const app = express();
   app.use(express.json());
 
   const COLLECTIONS_DIR = path.join(dataDir, "collections");
   const ENVIRONMENTS_DIR = path.join(dataDir, "environments");
   const METADATA_PATH = path.join(dataDir, "metadata.json");
+  
+  // Derive project name from dataDir parent (the cwd where hurler was run)
+  const derivedProjectName = projectName ?? path.basename(path.dirname(dataDir));
 
   async function ensureDirs() {
     await fs.mkdir(COLLECTIONS_DIR, { recursive: true });
@@ -43,6 +46,12 @@ export function createApp(dataDir: string) {
   async function writeMetadata(metadata: Metadata): Promise<void> {
     await fs.writeFile(METADATA_PATH, JSON.stringify(metadata, null, 2), "utf-8");
   }
+
+  // --- Project info endpoint ---
+
+  app.get("/api/project", (_req: Request, res: Response) => {
+    res.json({ name: derivedProjectName });
+  });
 
   // --- File endpoints ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import * as api from "@/lib/api";
 import type { RunResult, Metadata, FileInfo } from "@/lib/api";
 
 export default function App() {
+  const [projectName, setProjectName] = useState<string>("Hurler");
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [environments, setEnvironments] = useState<string[]>([]);
   const [activeFile, setActiveFile] = useState<string | null>(null);
@@ -36,6 +37,13 @@ export default function App() {
     () => !localStorage.getItem("hurler:activeEnvironment")
   );
 
+  // Fetch project info and update document title
+  const loadProjectInfo = useCallback(async () => {
+    const info = await api.getProjectInfo();
+    setProjectName(info.name);
+    document.title = `${info.name} | Hurler`;
+  }, []);
+
   const loadFiles = useCallback(async () => {
     const result = await api.listFiles();
     setFiles(result);
@@ -57,10 +65,11 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    loadProjectInfo();
     loadFiles();
     loadEnvironments();
     loadMetadata();
-  }, [loadFiles, loadEnvironments, loadMetadata]);
+  }, [loadProjectInfo, loadFiles, loadEnvironments, loadMetadata]);
 
   const handleUpdateMetadata = useCallback(async (updated: Metadata) => {
     setMetadata(updated);
@@ -163,6 +172,7 @@ export default function App() {
     <EnvProvider environment={activeEnvironment}>
     <TooltipProvider>
       <AppLayout
+        projectName={projectName}
         sidebar={
           <Sidebar
             files={files}

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useState, useCallback, useRef } from "react";
 
 interface AppLayoutProps {
+  projectName?: string;
   sidebar: ReactNode;
   editor: ReactNode;
   response: ReactNode;
@@ -64,7 +65,7 @@ function loadNumber(key: string, fallback: number): number {
   return fallback;
 }
 
-export function AppLayout({ sidebar, editor, response }: AppLayoutProps) {
+export function AppLayout({ projectName = "Hurler", sidebar, editor, response }: AppLayoutProps) {
   const [sidebarWidth, setSidebarWidth] = useState(() => loadNumber("hurler:sidebarWidth", 260));
   const [editorRatio, setEditorRatio] = useState(() => loadNumber("hurler:editorRatio", 0.55));
   const mainRef = useRef<HTMLDivElement>(null);
@@ -90,7 +91,7 @@ export function AppLayout({ sidebar, editor, response }: AppLayoutProps) {
   return (
     <div className="h-screen w-screen flex flex-col overflow-hidden">
       <div className="h-9 shrink-0 flex items-center px-3 border-b bg-muted/40">
-        <span className="text-sm font-semibold tracking-tight">Hurler</span>
+        <span className="text-sm font-semibold tracking-tight">{projectName}</span>
       </div>
       <div className="flex flex-1 min-h-0 overflow-hidden">
       <div style={{ width: sidebarWidth }} className="shrink-0 overflow-hidden">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,13 @@ async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+// Project
+export interface ProjectInfo {
+  name: string;
+}
+
+export const getProjectInfo = () => fetchJSON<ProjectInfo>(`${BASE}/project`);
+
 // Files
 export interface FileInfo {
   name: string;


### PR DESCRIPTION
Fixes #37

## Changes
- Added `/api/project` endpoint that returns the project name (derived from the directory where hurler was started)
- Header now shows the project name instead of static "Hurler"
- Document title updates to `<project> | Hurler` format

## Preview
https://hurler-preview.sidia.li

(Note: preview server shows "hurler-preview" as that's the directory name there)