### PR TITLE
fix: refresh env variables when environment is saved

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,9 @@ export default function App() {
   
   // Track which files have pending (unsaved) changes for sidebar indicator
   const [pendingFiles, setPendingFiles] = useState<Set<string>>(new Set());
+  
+  // Trigger re-fetch of env variables when environments are updated
+  const [envRefreshKey, setEnvRefreshKey] = useState(0);
 
   // Fetch project info and update document title
   const loadProjectInfo = useCallback(async () => {
@@ -290,7 +293,7 @@ export default function App() {
   }, []);
 
   return (
-    <EnvProvider environment={activeEnvironment}>
+    <EnvProvider environment={activeEnvironment} refreshKey={envRefreshKey}>
     <TooltipProvider>
       <AppLayout
         projectName={projectName}
@@ -332,6 +335,7 @@ export default function App() {
         onClose={() => setShowEnvEditor(false)}
         environments={environments}
         onRefresh={loadEnvironments}
+        onEnvChange={() => setEnvRefreshKey((k) => k + 1)}
       />
       <EnvPickerModal
         open={showEnvPicker && environments.length > 0}

--- a/src/components/env-editor.tsx
+++ b/src/components/env-editor.tsx
@@ -30,6 +30,7 @@ interface EnvEditorProps {
   onClose: () => void;
   environments: string[];
   onRefresh: () => void;
+  onEnvChange?: () => void;
 }
 
 interface EnvVar {
@@ -42,6 +43,7 @@ export function EnvEditor({
   onClose,
   environments,
   onRefresh,
+  onEnvChange,
 }: EnvEditorProps) {
   const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
   const [variables, setVariables] = useState<EnvVar[]>([]);
@@ -142,6 +144,7 @@ export function EnvEditor({
     }
     await api.updateEnvironment(selectedEnv, vars, secs);
     setIsDirty(false);
+    onEnvChange?.();
   };
 
   const handleCreateEnv = async () => {

--- a/src/lib/env-context.tsx
+++ b/src/lib/env-context.tsx
@@ -24,9 +24,11 @@ const EnvContext = createContext<EnvContextValue>({
 
 export function EnvProvider({
   environment,
+  refreshKey,
   children,
 }: {
   environment: string | null;
+  refreshKey?: number;
   children: ReactNode;
 }) {
   const [variables, setVariables] = useState<string[]>([]);
@@ -65,7 +67,7 @@ export function EnvProvider({
         setVariablesWithType([]);
       })
       .finally(() => setIsLoading(false));
-  }, [environment]);
+  }, [environment, refreshKey]);
 
   return (
     <EnvContext.Provider value={{ environment, variables, secrets, variablesWithType, isLoading }}>


### PR DESCRIPTION
Fixes #46

## Changes
- Added `refreshKey` prop to `EnvProvider` context
- `EnvEditor` calls `onEnvChange` callback when environment is saved
- `App.tsx` increments the refresh key on save, triggering re-fetch of variables

## Testing
1. Select an environment
2. Go to a request and type `{{` to see autocomplete
3. Open env settings, add a new variable, save
4. Type `{{` again - new variable should appear immediately
5. The highlighting should also update (green for defined, red for undefined)