### PR TITLE
fix: open env settings with active environment selected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,6 +336,7 @@ export default function App() {
         environments={environments}
         onRefresh={loadEnvironments}
         onEnvChange={() => setEnvRefreshKey((k) => k + 1)}
+        activeEnvironment={activeEnvironment}
       />
       <EnvPickerModal
         open={showEnvPicker && environments.length > 0}

--- a/src/components/env-editor.tsx
+++ b/src/components/env-editor.tsx
@@ -31,6 +31,7 @@ interface EnvEditorProps {
   environments: string[];
   onRefresh: () => void;
   onEnvChange?: () => void;
+  activeEnvironment?: string | null;
 }
 
 interface EnvVar {
@@ -44,8 +45,16 @@ export function EnvEditor({
   environments,
   onRefresh,
   onEnvChange,
+  activeEnvironment,
 }: EnvEditorProps) {
   const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
+  
+  // Select active environment when modal opens
+  useEffect(() => {
+    if (open && activeEnvironment && environments.includes(activeEnvironment)) {
+      setSelectedEnv(activeEnvironment);
+    }
+  }, [open, activeEnvironment, environments]);
   const [variables, setVariables] = useState<EnvVar[]>([]);
   const [secrets, setSecrets] = useState<EnvVar[]>([]);
   const [showNewEnvDialog, setShowNewEnvDialog] = useState(false);


### PR DESCRIPTION
Fixes #48

## Changes
- Added `activeEnvironment` prop to `EnvEditor`
- Modal now auto-selects the active environment when opened

## Testing
1. Select an environment from the dropdown
2. Click the env settings (gear) button
3. The modal should open with that environment already selected and loaded