### PR TITLE
feat: save captures to environment variables

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -14,9 +14,10 @@ interface MetadataSection {
 interface Metadata {
   sections: MetadataSection[];
   fileGroups: Record<string, string>;
+  captureToEnv?: Record<string, string[]>; // fileName -> capture names to persist
 }
 
-const DEFAULT_METADATA: Metadata = { sections: [], fileGroups: {} };
+const DEFAULT_METADATA: Metadata = { sections: [], fileGroups: {}, captureToEnv: {} };
 
 export function createApp(dataDir: string, projectName?: string, readOnly?: boolean) {
   const app = express();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,18 @@ export default function App() {
     }
   }, [activeFile, activeEnvironment, editorContent, savedContent, loadFiles]);
 
+  const handleSaveCaptureToEnv = useCallback(async (name: string, value: string) => {
+    if (!activeEnvironment) return;
+    // Read current environment
+    const env = await api.readEnvironment(activeEnvironment);
+    // Add the new variable (or update existing)
+    const updatedVars = { ...env.variables, [name]: value };
+    // Write back
+    await api.updateEnvironment(activeEnvironment, updatedVars, env.secrets);
+    // Refresh env context
+    setEnvRefreshKey((k) => k + 1);
+  }, [activeEnvironment]);
+
   const isDirty = editorContent !== savedContent;
   
   // Keep ref in sync for beforeunload handler
@@ -332,7 +344,13 @@ export default function App() {
           />
         }
         response={
-          <ResponsePanel result={runResult} isRunning={isRunning} hurlSource={savedContent} />
+          <ResponsePanel 
+            result={runResult} 
+            isRunning={isRunning} 
+            hurlSource={savedContent}
+            environment={activeEnvironment}
+            onSaveCaptureToEnv={handleSaveCaptureToEnv}
+          />
         }
       />
       <EnvEditor

--- a/src/components/response-panel.tsx
+++ b/src/components/response-panel.tsx
@@ -1,12 +1,17 @@
+import { useState } from "react";
 import type { RunResult } from "@/lib/api";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, XCircle, Save, Loader2, Check } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface ResponsePanelProps {
   result: RunResult | null;
   isRunning: boolean;
   hurlSource: string;
+  environment?: string | null;
+  onSaveCaptureToEnv?: (name: string, value: string) => Promise<void>;
 }
 
 interface AssertResult {
@@ -96,7 +101,72 @@ function getFailureDetail(message: string): { actual: string; expected: string }
   return null;
 }
 
-export function ResponsePanel({ result, isRunning, hurlSource }: ResponsePanelProps) {
+function CaptureRow({ 
+  name, 
+  displayValue, 
+  stringValue,
+  environment, 
+  onSave 
+}: { 
+  name: string; 
+  displayValue: string;
+  stringValue: string;
+  environment?: string | null; 
+  onSave?: (name: string, value: string) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = async () => {
+    if (!onSave || !environment) return;
+    setSaving(true);
+    try {
+      await onSave(name, stringValue);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex items-start gap-2 rounded-md px-2.5 py-2 text-xs font-mono bg-blue-500/5">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="font-semibold text-blue-700 dark:text-blue-400">{name}</span>
+          <span className="text-muted-foreground">=</span>
+          <span className="break-all text-foreground">{displayValue}</span>
+        </div>
+      </div>
+      {environment && onSave && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : saved ? (
+                <Check className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Save to environment</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+export function ResponsePanel({ result, isRunning, hurlSource, environment, onSaveCaptureToEnv }: ResponsePanelProps) {
   if (isRunning) {
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -260,19 +330,18 @@ export function ResponsePanel({ result, isRunning, hurlSource }: ResponsePanelPr
                   const displayValue = typeof c.value === "string" 
                     ? c.value 
                     : JSON.stringify(c.value);
+                  const stringValue = typeof c.value === "string" 
+                    ? c.value 
+                    : JSON.stringify(c.value);
                   return (
-                    <div
+                    <CaptureRow
                       key={i}
-                      className="flex items-start gap-2 rounded-md px-2.5 py-2 text-xs font-mono bg-blue-500/5"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-baseline gap-2">
-                          <span className="font-semibold text-blue-700">{c.name}</span>
-                          <span className="text-muted-foreground">=</span>
-                          <span className="break-all text-foreground">{displayValue}</span>
-                        </div>
-                      </div>
-                    </div>
+                      name={c.name}
+                      displayValue={displayValue}
+                      stringValue={stringValue}
+                      environment={environment}
+                      onSave={onSaveCaptureToEnv}
+                    />
                   );
                 })}
               </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -95,6 +95,7 @@ export interface Section {
 export interface Metadata {
   sections: Section[];
   fileGroups: Record<string, string>;
+  captureToEnv?: Record<string, string[]>; // fileName -> capture names to persist
 }
 
 export const getMetadata = () => fetchJSON<Metadata>(`${BASE}/metadata`);


### PR DESCRIPTION
Fixes #52

## Changes
- Added "Save to env" button next to each captured value in response panel
- Clicking saves the capture value to the active environment as a variable
- Shows loading spinner during save and checkmark on success
- Button only visible when an environment is selected

## Testing
1. Select an environment
2. Create a request with a capture (e.g. `token: jsonpath "$.token"`)
3. Run the request
4. In the Captures tab, click the save icon next to the captured value
5. Open env settings - the variable should be there