### PR TITLE
fix: red unsaved dot appearing incorrectly on file select

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,12 +281,22 @@ export default function App() {
   // Handle content changes - store pending changes
   const handleEditorChange = useCallback((content: string) => {
     setEditorContent(content);
-    // Store pending changes as user types
     if (activeFile) {
-      setPendingContent(activeFile, content);
-      setPendingFiles(prev => new Set(prev).add(activeFile));
+      // Only mark as pending if content actually differs from saved
+      if (content !== savedContent) {
+        setPendingContent(activeFile, content);
+        setPendingFiles(prev => new Set(prev).add(activeFile));
+      } else {
+        // Content matches saved - clear pending state for this file
+        clearPendingContent(activeFile);
+        setPendingFiles(prev => {
+          const next = new Set(prev);
+          next.delete(activeFile);
+          return next;
+        });
+      }
     }
-  }, [activeFile]);
+  }, [activeFile, savedContent]);
   
   // Warn user before leaving if there are unsaved changes
   useEffect(() => {


### PR DESCRIPTION
The `handleEditorChange` function was adding files to `pendingFiles` unconditionally, even when the content matched `savedContent`. This caused the red dot to appear when:

1. Editor fired `onChange` during initialization with same content
2. User undid all changes back to original state

## Fix
Only mark as pending when content actually differs from saved, and clear pending state when content matches saved.

## Bonus
This also means if you make changes and then undo them all (Cmd+Z back to original), the red dot disappears - which is the correct behavior.

Fixes #55