### PR TITLE
feat: add confirmation dialogs to delete actions

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,56 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={variant}
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/env-editor.tsx
+++ b/src/components/env-editor.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
   Select,
   SelectContent,
@@ -63,6 +64,7 @@ export function EnvEditor({
   const [newEnvName, setNewEnvName] = useState("");
   const [isDirty, setIsDirty] = useState(false);
   const [showSecretValues, setShowSecretValues] = useState<Record<number, boolean>>({});
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (selectedEnv) {
@@ -210,7 +212,7 @@ export function EnvEditor({
               <Plus className="h-4 w-4" />
             </Button>
             {selectedEnv && (
-              <Button variant="destructive" size="icon" onClick={handleDeleteEnv} disabled={readOnly}>
+              <Button variant="destructive" size="icon" onClick={() => setShowDeleteConfirm(true)} disabled={readOnly}>
                 <Trash2 className="h-4 w-4" />
               </Button>
             )}
@@ -399,6 +401,17 @@ export function EnvEditor({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        title="Delete environment"
+        description={`Are you sure you want to delete the "${selectedEnv}" environment? All variables and secrets will be permanently deleted.`}
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={handleDeleteEnv}
+      />
     </>
   );
 }

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
   Select,
   SelectContent,
@@ -242,6 +243,7 @@ export function Sidebar({
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
   const [editingSectionId, setEditingSectionId] = useState<string | null>(null);
   const [editingSectionName, setEditingSectionName] = useState("");
+  const [deletingFile, setDeletingFile] = useState<string | null>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
 
   const sensors = useSensors(
@@ -451,7 +453,7 @@ export function Sidebar({
             disabled={readOnly}
             onClick={(e) => {
               e.stopPropagation();
-              onDeleteFile(fileInfo.name);
+              setDeletingFile(fileInfo.name);
             }}
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -676,6 +678,22 @@ export function Sidebar({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        open={deletingFile !== null}
+        onOpenChange={(open) => !open && setDeletingFile(null)}
+        title="Delete request"
+        description={`Are you sure you want to delete "${deletingFile}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={() => {
+          if (deletingFile) {
+            onDeleteFile(deletingFile);
+            setDeletingFile(null);
+          }
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Adds confirmation dialogs before deleting:
- **Request files** (from sidebar context menu)
- **Environments** (from env settings modal)

## Implementation
- Created reusable `ConfirmDialog` component
- Destructive variant styling (red confirm button)
- Clear messaging about what will be deleted

## Screenshots
Dialog shows the name of the item being deleted and warns that the action cannot be undone.

Fixes #57